### PR TITLE
Use latest spark and an almost recent java version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <name>Spark + Atoti student project</name>
 
   <properties>
-    <java.version>17</java.version>
+    <java.version>16</java.version>
     <junit.version>5.8.1</junit.version>
   </properties>
 
@@ -25,6 +25,11 @@
       <artifactId>assertj-core</artifactId>
       <version>3.21.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.13</artifactId>
+      <version>3.2.0</version>
     </dependency>
   </dependencies>
 
@@ -44,6 +49,9 @@
             <compileSourceRoots>
               <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
             </compileSourceRoots>
+            <compilerArgs>
+              <arg>--enable-preview</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>
@@ -84,6 +92,9 @@
             <version>${junit.version}</version>
           </dependency>
         </dependencies>
+        <configuration>
+          <argLine>--enable-preview --illegal-access=permit</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/io/atoti/spark/TestDiscovery.java
+++ b/src/test/java/io/atoti/spark/TestDiscovery.java
@@ -1,30 +1,38 @@
 package io.atoti.spark;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.net.URISyntaxException;
-import java.nio.file.Path;
+import java.net.URL;
 import java.util.Objects;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
 
 public class TestDiscovery {
 
+  SparkSession spark =
+      SparkSession.builder().appName("Spark Atoti").config("spark.master", "local").getOrCreate();
+
   @Test
   void testDiscovery() throws URISyntaxException {
     final ClassLoader cl = Thread.currentThread().getContextClassLoader();
-    final var url = Objects.requireNonNull(cl.getResource("csv/basic.csv"), "Cannot find file");
-    final var path = Path.of(url.toURI());
+    final URL url = Objects.requireNonNull(cl.getResource("csv/basic.csv"), "Cannot find file");
 
-    if (true) {
-      throw new UnsupportedOperationException("Load the path as as dataframe and ");
-    }
-    final Object dataframe = null; // convert path to dataframe
-    Discovery.discoverDataframe(dataframe);
+    System.out.println(url);
 
-    assertThat(dataframe).isNotNull();
-    // TODO: add more assertions about the discovered values in the dataframe
-    // we should see 3 columns: id, label and value
-    // we should see that id is a number, label is something string-y and value is a number, ideally
-    // floating.
+    System.out.println(url.toURI().getPath());
+    final Dataset<Row> dataframe =
+        spark
+            .read()
+            .format("csv")
+            .option("sep", ";")
+            .option("header", true)
+            .option("dateFormat", "dd/MM/yyyy")
+            .option("inferSchema", true)
+            .load(url.toURI().getPath());
+    //    Discovery.discoverDataframe(dataframe);
+
+    dataframe.show();
+    dataframe.printSchema();
   }
 }


### PR DESCRIPTION
Find a recent version of java working with Spark.

Testing with the latest jdk, name jdk 17, and the latest version of Scala + Spark, I found that unfortunately Spark was not ready for this JDK yet.
This issue being a well-known bug for us, I found a way to make it work with a recent enough version of Java: jdk16.
It required enabling some options to have the latest of the Java syntax and the JVM not complain. The options are `--enable-preview --illegal-access=permit`, in case you would need to put them in your IDE.

I created this PR to check with you if that change was ok. Quickly looking ways to download jdk16, I saw that various vendors removed their builds. But there are still docker images, if that ok with you. On linux system, the good tool SDKMAN is providing versions of JDK 16.
So tell me if this is an issue. We can always return to some older versions, though your experience will be a bit degraded.

BTW I filed an issue about this to Spark team. Let's see what it becomes :crossed_fingers: 
https://issues.apache.org/jira/browse/SPARK-35557